### PR TITLE
Mandatory arguments for partials, fix partial-block scope

### DIFF
--- a/src/BMX.hs
+++ b/src/BMX.hs
@@ -4,7 +4,7 @@
 -- embedded in Haskell for static or server-side rendering.
 --
 -- BMX templates can be written and maintained without any Haskell
--- knowledge, while the rendering logic (described through 'Helper'
+-- knowledge, while the control flow (described through 'Helper'
 -- functions) can be extended or replaced by the user.
 
 module BMX (
@@ -92,12 +92,29 @@ import           BMX.TH (bmx, templateFile, partialFile, partialDir)
 -- (object) will result in an error. Failed lookups will not render as
 -- empty strings. Use `if` or `unless` explicitly instead.
 --
--- * Shadowing is restricted.
+-- * Shadowing is restricted. Redefining variables or partials while
+-- executing is difficult.
 --
 -- * Heavy restrictions on mutable state. Updates are restricted to
 -- the current scope.
 --
+-- * Partials do not inherit their parent context, unless it is
+-- manually passed with @{{> partialName . }}@. Pass parameters
+-- explicitly using hash syntax instead, e.g.
+-- @{{> partialName id=id name=someone.name }}@.
+--
 -- * To Be Documented
+--
+-- A few Handlebars features have not been implemented:
+--
+-- * Option hashes for helpers are not implemented, though the syntax
+-- will parse.
+--
+-- * Partial blocks are evaluated in the outer context, as per
+-- Handlebars, but this is done eagerly; it is thus not possible to
+-- override variables or provide a custom context to a partial block.
+-- i.e. in @{{> \@partial-block abc def=ghi }}@, @abc@ and @def@ have
+-- no effect.
 
 
 -- $templates BMX templates are syntactically compatible with

--- a/src/BMX/Eval.hs
+++ b/src/BMX/Eval.hs
@@ -221,13 +221,14 @@ evalPartialBlock :: (Applicative m, Monad m)
                  -> Positioned Expr -> Maybe (Positioned Expr) -> Positioned Hash
                  -> Positioned Template
                  -> BMX m Page
-evalPartialBlock l1 r1 l2 r2 e ee hash (b :@ _) =
-  -- Register b as @partial-block
+evalPartialBlock l1 r1 l2 r2 e ee hash (b :@ _) = do
+  -- Evaluate b in the current context, register result as @partial-block
+  block <- eval b
   -- Call evalPartial with custom error function (const (eval b)) - failover
-  withData "partial-block" blockData (evalPartial l1 r1 l2 r2 e ee hash failOver)
+  withData "partial-block" (blockData block) (evalPartial l1 r1 l2 r2 e ee hash (failOver block))
   where
-    blockData = DataPartial (partial (eval b))
-    failOver = const (eval b)
+    blockData bl = DataPartial (partial (return bl))
+    failOver bl = const (return bl)
 
 -- | Hashes mean different things in different contexts:
 --

--- a/test/Test/BMX/Eval.hs
+++ b/test/Test/BMX/Eval.hs
@@ -245,6 +245,11 @@ prop_eval_unit_partial_block_data = once $
   (testContext `usingPartials` [("mypartial", testPartialBlock)])
     === pure "block = My First Blog Post!"
 
+-- a partial block is evaluated using outer scope, not inner
+prop_eval_unit_partial_block_scoping = once . isLeft $
+  rendersTo "{{#> mypartial author }}{{name}}{{/mypartal}}"
+  (testContext `usingPartials` [("mypartial", testPartialBlock)])
+
 -- Can look up item in list
 prop_eval_unit_list_index_1 = once $
   rendersTo "{{ list.[0] }}" testContext === pure "why"


### PR DESCRIPTION
Before I sink too much time into making this work, we should probably figure out if we want it.

In short, clear the context before any partial is invoked. This forces a more disciplined use of handlebars, where each partial has its arguments passed explicitly. We do this already almost everywhere as far as I can tell. Usually we pass a custom context to a partial; this only affects the times when we don't (e.g. dialogLoggedIn)

You can still get around it by using `../abcde` notation. That could be another item on the hitlist, it's pretty dodgy. Could also write a linter that complains about it
