### PR TITLE
Better partial and helper errors

### DIFF
--- a/src/BMX/Data.hs
+++ b/src/BMX/Data.hs
@@ -130,12 +130,13 @@ packState bst = do
     , evalHelpers = helpers
     , evalPartials = partials
     , evalDecorators = decorators
+    , evalBreadcrumbs = mempty
     }
 
-mapUnique :: (Text -> EvalError) -> [(Text, a)] -> Either BMXError (Map Text a)
+mapUnique :: (Text -> EvalErrorT) -> [(Text, a)] -> Either BMXError (Map Text a)
 mapUnique e = foldM foldFun M.empty
   where foldFun m (k, v)  = if M.member k m
-          then Left (BMXEvalError (e k))
+          then Left (BMXEvalError (EvalError (e k) mempty))
           else Right (M.insert k v m)
 
 boxContext :: [(Text, BMXValue)] -> Either BMXError Context

--- a/src/BMX/Data/Position.hs
+++ b/src/BMX/Data/Position.hs
@@ -13,6 +13,7 @@ module BMX.Data.Position (
   , between
   , renderPosition
   , renderSrcInfo
+  , renderSrcInfoRange
   ) where
 
 import           Data.Data (Data, Typeable)
@@ -28,7 +29,7 @@ data Position = Position {
   } deriving (Data, Eq, Ord, Show, Typeable)
 
 renderPosition :: Position -> Text
-renderPosition pos = "Line " <> tshow (posLine pos) <> ", Col " <> tshow (posColumn pos)
+renderPosition pos = "line " <> tshow (posLine pos) <> ", col " <> tshow (posColumn pos)
 
 -- | A range in the source file.
 data SrcInfo
@@ -44,7 +45,12 @@ instance Monoid SrcInfo where
 
 renderSrcInfo :: SrcInfo -> Text
 renderSrcInfo NoInfo = "<no location info>"
-renderSrcInfo (SrcLoc a b) = renderPosition a <> " -- " <> renderPosition b
+renderSrcInfo (SrcLoc a _) = renderPosition a
+
+renderSrcInfoRange :: SrcInfo -> Text
+renderSrcInfoRange NoInfo = "<no location info>"
+renderSrcInfoRange (SrcLoc a b) = renderPosition a <> " -- " <> renderPosition b
+
 
 -- | A value and character range pair
 data Positioned a = !a :@ !SrcInfo

--- a/test/Test/BMX/Orphans.hs
+++ b/test/Test/BMX/Orphans.hs
@@ -15,7 +15,12 @@ import           BMX.Data
 
 import           P
 
+deriving instance Eq Breadcrumbs
+deriving instance Eq Breadcrumb
+
 deriving instance Eq EvalError
+deriving instance Eq EvalErrorT
+
 deriving instance Eq FunctionError
 
 deriving instance Eq BMXError


### PR DESCRIPTION
stores an explicit stack of partial / helper invocations in the monad's state. uses that to print out error messages that could _actually be used to find the problem_

increases space usage, linear in the depth of partial/helper nesting. that shouldn't be a big deal, because partials generally aren't nested too deeply (unless you're using corecursive partials to perform a loop, in which case... please stop)

e.g.

Error occurring in a buried partial:

``` handlebars
{{#* inline "first" }} {{>second}} {{/inline}}
{{#* inline "second" }} {{ gnar }} {{/inline}}
{{>first}}
```

```
Rendering error at line 2, col 28:
  Invoked value 'gnar' is not defined
    In partial 'second' invoked at line 1, col 27
    In partial 'first' invoked at line 3, col 4
```

Arity / type error in a helper (these error messages really need to be clearer, but now you know where the problem is):

``` handlebars
{{ lookup 55 25 "abcde" }}
```

```
Rendering error:
  Error applying helper
    Type mismatch (expected context, got number)

    In helper 'lookup' invoked at line 1, col 4
```

Detailed error messages could easily be retrofitted to local parts of the template using this machinery, e.g. to blocks.
