### PR TITLE
Linear time rendering

### DIFF
--- a/ambiata-bmx.cabal
+++ b/ambiata-bmx.cabal
@@ -32,6 +32,7 @@ library
                      , scientific                      == 0.3.*
                      , filemanip                       == 0.3.*
                      , filepath                        == 1.3.*
+                     , dlist                           == 0.7.*
 
   build-tools:         happy
 
@@ -129,6 +130,7 @@ test-suite test
                      , mtl
                      , transformers
                      , deepseq
+                     , dlist
 
 
 benchmark bench

--- a/test/Test/BMX/Arbitrary.hs
+++ b/test/Test/BMX/Arbitrary.hs
@@ -6,6 +6,7 @@ module Test.BMX.Arbitrary where
 
 import           Data.Char (isAlpha)
 import           Data.Data
+import qualified Data.DList as DL
 import           Data.Generics.Aliases
 import           Data.Generics.Schemes
 import           Data.List (nubBy, zipWith)
@@ -108,6 +109,10 @@ instance Arbitrary Page where
     where bodies = (\t -> Formatter lf rf t t2 t3) <$> shrink t1
           leftsh = (\t -> Formatter lf rf t1 t t3) <$> shrink t2
           rightsh = (\t -> Formatter lf rf t1 t2 t) <$> shrink t3
+
+instance Arbitrary Chunk where
+  arbitrary = Chunk . DL.fromList <$> arbitrary
+  shrink (Chunk xs) = Chunk . DL.fromList <$> shrink (DL.toList xs)
 
 --------------------------------------------------------------------------------
 -- AST / parser generators

--- a/test/Test/BMX/Orphans.hs
+++ b/test/Test/BMX/Orphans.hs
@@ -8,6 +8,7 @@
 module Test.BMX.Orphans where
 
 import           Data.Data
+import           Data.String (IsString (..))
 import qualified Data.Text as T
 import           GHC.Generics
 
@@ -53,10 +54,6 @@ deriving instance Generic Tokens
 
 deriving instance Generic Token
 
-deriving instance Generic Page
-deriving instance Data Page
-deriving instance Typeable Page
-
 deriving instance Generic Context
 deriving instance Data Context
 deriving instance Typeable Context
@@ -74,3 +71,6 @@ deriving instance Generic Position
 deriving instance Generic SrcInfo
 
 deriving instance Generic a => Generic (Positioned a)
+
+instance IsString Chunk where
+  fromString = singleChunk . fromString


### PR DESCRIPTION
Kind of thought all the Text appends would fuse, but... no, things do not work that way. so I reimplemented lazy Text in DList form to get an O(1) mappend, and linearise it at the end as a Text stream.
- Order of magnitude speedup from manually wrangling Text chunks, 30s -> 60ms in the pathological case
- A nice (~10%) constant factor speedup from switch to `DList` from `[Text]` (the `[Text]` commit was squashed, whoops)
