### PR TITLE
Exclude autogen files from sdist

### DIFF
--- a/ambiata-bmx.cabal
+++ b/ambiata-bmx.cabal
@@ -71,8 +71,6 @@ library
                        BMX.Data.Token                       
                        BMX.Data.Value
 
-                       Paths_ambiata_bmx
-
 executable bmx
   ghc-options:      -Wall -threaded -O2
   build-depends:


### PR DESCRIPTION
Was preventing mafia from caching BMX across different projects
