### PR TITLE
Add test cabal to export Arbitrary

### DIFF
--- a/test/ambiata-bmx-test.cabal
+++ b/test/ambiata-bmx-test.cabal
@@ -1,0 +1,20 @@
+name:                  ambiata-bmx-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base
+                     , ambiata-bmx
+                     , ambiata-p
+                     , containers                      == 0.5.*
+                     , dlist                           == 0.7.*
+                     , QuickCheck
+                     , quickcheck-instances
+                     , syb
+                     , text
+
+  exposed-modules:
+                       Test.BMX.Arbitrary
+                       Test.BMX.Orphans


### PR DESCRIPTION
/cc @thumphries 

This will be needed when we want to generate an arbitrary `BMXValue` outside of bmx (eg. helper tests).
