### PR TITLE
Add lexer benchmark

### DIFF
--- a/test/bench.hs
+++ b/test/bench.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 
 import           BMX
+import           BMX.Lexer (tokenise)
 
 import           Criterion.Main
 import           Criterion.Types (Config (..))
@@ -79,11 +80,17 @@ main = do
             reportFile = Just "dist/build/bmx.hs-bench.html"
           , csvFile    = Just "dist/build/bmx.hs-bench.csv"
           }
+      flatLexBm = whnf tokenise . flatTemplateTextStrict
       flatParseBm = whnf templateFromText . flatTemplateTextStrict
       flatRenderBm = whnf flatRenderer . flatTemplate
 
   defaultMainWith cfg [
-      bgroup "templateFromText" [
+      bgroup "tokenise" [
+          bench "flat-100"    $ flatLexBm 100
+        , bench "flat-500"    $ flatLexBm 500
+        , bench "flat-1000"   $ flatLexBm 1000
+        ]
+    , bgroup "templateFromText" [
           bench "flat-100"    $ flatParseBm 100
         , bench "flat-500"    $ flatParseBm 500
         , bench "flat-1000"   $ flatParseBm 1000


### PR DESCRIPTION
just shows the lexer is 80 or 90% of the timesink in `templateToText`

I think it can be done in a single pass with Alex. low hanging fruit to improve the build time for `bikeshed-templates`

```
Benchmark bench: RUNNING...
benchmarking tokenise/flat-100
time                 45.49 ms   (44.87 ms .. 46.17 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 45.91 ms   (45.51 ms .. 46.47 ms)
std dev              867.7 μs   (611.5 μs .. 1.285 ms)

benchmarking tokenise/flat-500
time                 235.6 ms   (231.2 ms .. 242.7 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 236.9 ms   (236.0 ms .. 238.5 ms)
std dev              1.608 ms   (106.8 μs .. 1.962 ms)
variance introduced by outliers: 16% (moderately inflated)

benchmarking tokenise/flat-1000
time                 460.6 ms   (449.3 ms .. 483.3 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 471.5 ms   (465.3 ms .. 476.2 ms)
std dev              7.334 ms   (0.0 s .. 8.232 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking templateFromText/flat-100
time                 54.21 ms   (53.68 ms .. 54.90 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 54.49 ms   (54.25 ms .. 54.75 ms)
std dev              468.0 μs   (345.0 μs .. 647.1 μs)

benchmarking templateFromText/flat-500
time                 276.7 ms   (270.6 ms .. 287.9 ms)
                     1.000 R²   (0.998 R² .. 1.000 R²)
mean                 275.8 ms   (271.8 ms .. 278.0 ms)
std dev              3.841 ms   (537.1 μs .. 4.892 ms)
variance introduced by outliers: 16% (moderately inflated)

benchmarking templateFromText/flat-1000
time                 536.4 ms   (491.1 ms .. 625.8 ms)
                     0.996 R²   (0.994 R² .. 1.000 R²)
mean                 574.7 ms   (550.4 ms .. 592.5 ms)
std dev              26.91 ms   (0.0 s .. 30.73 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking renderTemplate/flat-100
time                 5.922 ms   (5.790 ms .. 6.029 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 5.926 ms   (5.884 ms .. 5.969 ms)
std dev              131.8 μs   (111.9 μs .. 165.4 μs)

benchmarking renderTemplate/flat-500
time                 30.11 ms   (29.77 ms .. 30.44 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 30.54 ms   (30.32 ms .. 30.74 ms)
std dev              463.2 μs   (354.0 μs .. 619.5 μs)

benchmarking renderTemplate/flat-1000
time                 58.95 ms   (58.31 ms .. 59.71 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 59.51 ms   (59.05 ms .. 59.94 ms)
std dev              782.6 μs   (475.1 μs .. 1.268 ms)
```
