### PR TITLE
Add all combinator

### DIFF
--- a/src/BMX/Function.hs
+++ b/src/BMX/Function.hs
@@ -30,6 +30,8 @@ module BMX.Function (
   , nullable
   , optional
   , eitherA
+  , one
+  , rest
   , string
   , number
   , boolean

--- a/test/Test/BMX/Arbitrary.hs
+++ b/test/Test/BMX/Arbitrary.hs
@@ -16,7 +16,7 @@ import qualified Data.Text as T
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
-import           BMX.Data
+import           BMX.Data hiding (rest)
 import           BMX.Lexer (validIdChar)
 
 import           Test.BMX.Orphans ()


### PR DESCRIPTION
Context: when writing helpers, we use an applicative / monadic interface to consume the function's arguments in a typed way. Usually we use stuff from P/Alternative like `many` `optional` `eitherA`. We require that every argument is handled in some way, because the `runFunction` function appends a sneaky `eof` parser to the end.

If `many string` is the last thing to run, it's effectively `all string`. it will give up as soon as it sees something that's not a string, leaving it on the queue unconsumed, so that sneaky `eof` fails.. leading to an error message about unconsumed arguments. using `all` will give the type error you'd expect in that case, 'expected string, saw int'

Needs a better name

also needs tests, but looks correct to me. i'll ping people when its good to go
